### PR TITLE
Update chroot-script.sh

### DIFF
--- a/chroot-script.sh
+++ b/chroot-script.sh
@@ -26,7 +26,7 @@ fi
 pacman --noconfirm -Sy efibootmgr $editor base-devel git
 
 case $network in
-  systemd-network)
+  systemd-networkd)
     systemctl enable systemd-networkd
     ;;
 


### PR DESCRIPTION
this is a typo because if it remains as it is, it would simply copy the contents of /etc/systemd/network to /mnt/etc/systemd/network... then it would install networkmanager.. however, it wouldn't enable systemd-networkd service